### PR TITLE
sbat: Improve the example

### DIFF
--- a/sbat/tests/example.rs
+++ b/sbat/tests/example.rs
@@ -1,41 +1,59 @@
-// Copyright 2023 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 use sbat::{
     ImageSbat, ImageSbatArray, ParseError, RevocationSbat, RevocationSbatArray,
     ValidationResult,
 };
+#[cfg(feature = "alloc")]
+use sbat::{ImageSbatVec, RevocationSbatVec};
 
+const IMAGE_SBAT_A1: &[u8] = b"sbat,1\nCompA,1";
+const IMAGE_SBAT_A2: &[u8] = b"sbat,1\nCompA,2";
+const REVOCATION_SBAT: &[u8] = b"sbat,1,2021030218
+CompA,2";
+
+/// This example uses fixed-size array types that do not allocate.
 #[test]
-fn example() -> Result<(), ParseError> {
-    // This example uses fixed-size array types that do not allocate. If
-    // the `alloc` feature is enabled, you can use `ImageSbatVec` and
-    // `RevocationSbatVec` instead.
+fn example_fixed_size() -> Result<(), ParseError> {
+    // Parse the image and revocation SBAT.
+    let image_sbat = ImageSbatArray::<10>::parse(IMAGE_SBAT_A1)?;
+    let revocations = RevocationSbatArray::<10>::parse(REVOCATION_SBAT)?;
 
-    // Parse the image SBAT.
-    let image_sbat = ImageSbatArray::<10>::parse(b"sbat,1,CompA,2")?;
+    // Check that the image is revoked.
+    assert_eq!(
+        revocations.validate_image(&image_sbat),
+        ValidationResult::Revoked(*image_sbat.entries().last().unwrap()),
+    );
 
-    // Parse the revocations SBAT.
-    let revocations =
-        RevocationSbatArray::<10>::parse(b"sbat,1,2021030218\nCompA,2")?;
-
-    // Check that the image is not revoked.
+    // Change the image's CompA generation to 1 and verify that it is no
+    // longer revoked.
+    let image_sbat = ImageSbatArray::<10>::parse(IMAGE_SBAT_A2)?;
     assert_eq!(
         revocations.validate_image(&image_sbat),
         ValidationResult::Allowed,
     );
 
-    // Change the image's CompA generation to 1 and verify that it is
-    // revoked.
-    let image_sbat = ImageSbatArray::<10>::parse(b"sbat,1\nCompA,1")?;
+    Ok(())
+}
+
+/// This example uses `Vec`-like types that dynamically allocate.
+#[cfg(feature = "alloc")]
+#[test]
+fn example_vec() -> Result<(), ParseError> {
+    // Parse the image and revocation SBAT.
+    let image_sbat = ImageSbatVec::parse(IMAGE_SBAT_A1)?;
+    let revocations = RevocationSbatVec::parse(REVOCATION_SBAT)?;
+
+    // Check that the image is revoked.
     assert_eq!(
         revocations.validate_image(&image_sbat),
         ValidationResult::Revoked(*image_sbat.entries().last().unwrap()),
+    );
+
+    // Change the image's CompA generation to 1 and verify that it is no
+    // longer revoked.
+    let image_sbat = ImageSbatVec::parse(IMAGE_SBAT_A2)?;
+    assert_eq!(
+        revocations.validate_image(&image_sbat),
+        ValidationResult::Allowed,
     );
 
     Ok(())


### PR DESCRIPTION
It's a bit clearer now, and covers both the Array and Vec types.