### PR TITLE
Move shared package metadata to top-level Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,10 @@
 
 [workspace]
 members = ["sbat", "sbat-tool"]
+
+[workspace.package]
+edition = "2021"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/google/sbat-rs"
+rust-version = "1.64"
+version = "0.3.0"

--- a/sbat-tool/Cargo.toml
+++ b/sbat-tool/Cargo.toml
@@ -8,14 +8,15 @@
 
 [package]
 name = "sbat-tool"
-version = "0.3.0"
-edition = "2021"
-
 categories = ["command-line-utilities"]
 description = "UEFI Secure Boot Advanced Targeting (SBAT) command-line tool"
 keywords = ["sbat", "uefi", "cli"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/google/sbat-rs"
+
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 [dependencies]
 anyhow = "1.0.70"

--- a/sbat/Cargo.toml
+++ b/sbat/Cargo.toml
@@ -8,14 +8,15 @@
 
 [package]
 name = "sbat"
-version = "0.3.0"
-edition = "2021"
-
 categories = ["data-structures", "embedded", "no-std"]
 description = "UEFI Secure Boot Advanced Targeting (SBAT) no_std library"
 keywords = ["sbat", "uefi", "no_std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/google/sbat-rs"
+
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 [dependencies]
 arrayvec = { version = "0.7.0", default-features = false }


### PR DESCRIPTION
The `workspace.package` feature was introduced in 1.64, so also set `rust-version` to that version.