### PR TITLE
sbat: Add methods for parsing a Record as an Entry/Component

### DIFF
--- a/sbat/src/component.rs
+++ b/sbat/src/component.rs
@@ -6,7 +6,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use crate::Generation;
+use crate::csv::Record;
+use crate::{Generation, ParseError};
 use ascii::AsciiStr;
 
 /// SBAT component. This is the machine-readable portion of SBAT that is
@@ -26,5 +27,17 @@ impl<'a> Component<'a> {
     #[must_use]
     pub fn new(name: &AsciiStr, generation: Generation) -> Component {
         Component { name, generation }
+    }
+
+    /// Parse a `Component` from a `Record`.
+    pub(crate) fn from_record<const N: usize>(
+        record: &Record<'a, N>,
+    ) -> Result<Self, ParseError> {
+        Ok(Self {
+            name: record.get_field(0).ok_or(ParseError::TooFewFields)?,
+            generation: record
+                .get_field_as_generation(1)?
+                .ok_or(ParseError::TooFewFields)?,
+        })
     }
 }

--- a/sbat/src/revocations.rs
+++ b/sbat/src/revocations.rs
@@ -71,14 +71,7 @@ pub trait RevocationSbat<'a> {
             }
 
             revocations
-                .try_push(Component {
-                    name: record
-                        .get_field(0)
-                        .ok_or(ParseError::TooFewFields)?,
-                    generation: record
-                        .get_field_as_generation(1)?
-                        .ok_or(ParseError::TooFewFields)?,
-                })
+                .try_push(Component::from_record(&record)?)
                 .map_err(|_| ParseError::TooManyRecords)
         })?;
 


### PR DESCRIPTION
This deduplicates the Component parsing.