### PR TITLE
Rework CSV parsing into an iterator

### DIFF
--- a/sbat/src/image.rs
+++ b/sbat/src/image.rs
@@ -12,7 +12,7 @@
 //! executable. See the crate documentation for details of how it is
 //! used.
 
-use crate::csv::{parse_csv, trim_ascii_at_null, Record};
+use crate::csv::{trim_ascii_at_null, CsvIter, Record};
 use crate::{Component, ParseError, PushError};
 use ascii::AsciiStr;
 use core::fmt::{self, Formatter};
@@ -91,10 +91,11 @@ pub trait ImageSbat<'a> {
 
         let mut sbat = Self::default();
 
-        parse_csv(input, |record: Record<NUM_ENTRY_FIELDS>| {
+        for record in CsvIter::<NUM_ENTRY_FIELDS>::new(input) {
+            let record = record?;
             sbat.try_push(Entry::from_record(&record)?)
-                .map_err(|_| ParseError::TooManyRecords)
-        })?;
+                .map_err(|_| ParseError::TooManyRecords)?;
+        }
 
         Ok(sbat)
     }

--- a/sbat/src/image.rs
+++ b/sbat/src/image.rs
@@ -12,7 +12,7 @@
 //! executable. See the crate documentation for details of how it is
 //! used.
 
-use crate::csv::{parse_csv, Record};
+use crate::csv::{parse_csv, trim_ascii_at_null, Record};
 use crate::{Component, ParseError, PushError};
 use ascii::AsciiStr;
 use core::fmt::{self, Formatter};
@@ -87,6 +87,8 @@ pub trait ImageSbat<'a> {
     where
         Self: Default,
     {
+        let input = trim_ascii_at_null(input)?;
+
         let mut sbat = Self::default();
 
         parse_csv(input, |record: Record<NUM_ENTRY_FIELDS>| {

--- a/sbat/src/lib.rs
+++ b/sbat/src/lib.rs
@@ -81,6 +81,7 @@ mod csv;
 mod error;
 mod generation;
 mod image;
+mod lines;
 mod revocation_section;
 mod revocations;
 

--- a/sbat/src/lines.rs
+++ b/sbat/src/lines.rs
@@ -1,0 +1,75 @@
+use ascii::{AsciiChar, AsciiStr};
+
+// TODO: this is similar to the `Lines` iterator in the ascii crate, but
+// that type is not currently public:
+// https://github.com/tomprogrammer/rust-ascii/issues/101
+pub(crate) struct LineIter<'a> {
+    string: &'a AsciiStr,
+}
+
+impl<'a> LineIter<'a> {
+    pub(crate) fn new(string: &'a AsciiStr) -> Self {
+        Self { string }
+    }
+}
+
+impl<'a> Iterator for LineIter<'a> {
+    type Item = &'a AsciiStr;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.string.is_empty() {
+            return None;
+        }
+
+        if let Some(line_end) = self
+            .string
+            .chars()
+            .position(|chr| chr == AsciiChar::LineFeed)
+        {
+            let line = &self.string[..line_end];
+            // OK to unwrap: we know that line_end is a valid index,
+            // which means it's less than the length, which means it
+            // must be less than max usize.
+            self.string = &self.string[line_end.checked_add(1).unwrap()..];
+            if line.last() == Some(AsciiChar::CarriageReturn) {
+                // OK to unwrap: we know the line has at least one character.
+                Some(&line[..line.len().checked_sub(1).unwrap()])
+            } else {
+                Some(line)
+            }
+        } else {
+            let line = self.string;
+            self.string = &self.string[0..0];
+            Some(line)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lines(s: &str) -> Vec<&AsciiStr> {
+        LineIter::new(AsciiStr::from_ascii(s).unwrap()).collect::<Vec<_>>()
+    }
+
+    #[test]
+    fn test_line_iter() {
+        assert!(lines("").is_empty());
+        assert_eq!(lines("a"), ["a"]);
+        assert_eq!(lines("ab"), ["ab"]);
+
+        assert_eq!(lines("\n"), [""]);
+        assert_eq!(lines("\r\n"), [""]);
+        assert_eq!(lines("\r"), ["\r"]);
+
+        assert_eq!(lines("ab\n"), ["ab"]);
+        assert_eq!(lines("ab\r\n"), ["ab"]);
+
+        assert_eq!(lines("ab\ncd"), ["ab", "cd"]);
+        assert_eq!(lines("ab\r\ncd"), ["ab", "cd"]);
+
+        assert_eq!(lines("ab\ncd\n"), ["ab", "cd"]);
+        assert_eq!(lines("ab\ncd\n\n"), ["ab", "cd", ""]);
+    }
+}

--- a/sbat/src/revocations.rs
+++ b/sbat/src/revocations.rs
@@ -11,7 +11,7 @@
 //! Typically this data is read from a UEFI variable. See the crate
 //! documentation for details of how it is used.
 
-use crate::csv::{parse_csv, Record};
+use crate::csv::{parse_csv, trim_ascii_at_null, Record};
 use crate::{Component, Entry, ImageSbat, ParseError, PushError};
 use ascii::AsciiStr;
 use core::fmt::{self, Formatter};
@@ -60,6 +60,8 @@ pub trait RevocationSbat<'a> {
     where
         Self: Default,
     {
+        let input = trim_ascii_at_null(input)?;
+
         let mut revocations = Self::default();
 
         let mut first = true;


### PR DESCRIPTION
This is an internal cleanup to support a future API change to the image/revocation SBAT structs.