### PR TITLE
Prepare the `sbat` crate for having a small amount of `unsafe` code

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,6 +48,15 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo test -p sbat -F std
 
+  test-sbat-miri:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: rustup install nightly --profile minimal
+      - run: rustup component add miri --toolchain nightly
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo +nightly miri test -p sbat -F alloc
+
   test-sbat-tool:
     runs-on: ubuntu-latest
     steps:

--- a/sbat/src/lib.rs
+++ b/sbat/src/lib.rs
@@ -60,8 +60,8 @@
 //! [`Vec`]: https://doc.rust-lang.org/stable/alloc/vec/struct.Vec.html
 //! [`object`]: https://crates.io/crates/object
 
-#![forbid(unsafe_code)]
 #![warn(missing_docs)]
+#![warn(unsafe_code)]
 #![warn(clippy::arithmetic_side_effects)]
 #![warn(clippy::pedantic)]
 #![allow(clippy::enum_glob_use)]


### PR DESCRIPTION
(Splitting some changes out of https://github.com/google/sbat-rs/pull/56)

An upcoming change to the API will require a small amount of `unsafe`. Change the `forbid(unsafe_code)` to a `warn` so that we can `allow` unsafe in the few locations where it's needed.

Also add a [miri](https://github.com/rust-lang/miri) test job to the CI to help ensure we do the `unsafe` right.