### PR TITLE
sbat: Conditionally enable alloc feature of ascii crate

### DIFF
--- a/sbat/Cargo.toml
+++ b/sbat/Cargo.toml
@@ -28,5 +28,5 @@ ascii = { version = "1.0.0", default-features = false }
 log = { version = "0.4.0", default-features = false }
 
 [features]
-alloc = []
+alloc = ["ascii/alloc"]
 std = ["alloc"]


### PR DESCRIPTION
(Splitting this out of https://github.com/google/sbat-rs/pull/56)

