### PR TITLE
renovate: Switch to update-lockfile strategy

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,5 +6,5 @@
   "lockFileMaintenance": {
     "enabled": true
   },
-  "rangeStrategy": "replace"
+  "rangeStrategy": "update-lockfile"
 }


### PR DESCRIPTION
Support for this strategy was added in:
https://github.com/renovatebot/renovate/pull/25983

The behavior of the `replace` strategy seems to have changed (I'm guessing due to the above PR) such that we're getting a lot of PRs updating `Cargo.toml` that we don't want. Hopefully changing the stategy to `update-lockfile` will fix that.