### PR TITLE
Update tabled to 0.15.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "papergrid"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ccbe15f2b6db62f9a9871642746427e297b0ceb85f9a7f1ee5ff47d184d0c8"
+checksum = "9ad43c07024ef767f9160710b3a6773976194758c7919b17e63b863db0bdf7fb"
 dependencies = [
  "bytecount",
  "fnv",
@@ -254,9 +254,9 @@ dependencies = [
 
 [[package]]
 name = "tabled"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfe9c3632da101aba5131ed63f9eed38665f8b3c68703a6bb18124835c1a5d22"
+checksum = "4c998b0c8b921495196a48aabaf1901ff28be0760136e31604f7967b0792050e"
 dependencies = [
  "papergrid",
  "unicode-width",

--- a/sbat-tool/Cargo.toml
+++ b/sbat-tool/Cargo.toml
@@ -26,4 +26,4 @@ fs-err = "2.9.0"
 itertools = "0.12.0"
 object = { version = "0.32.1", default-features = false, features = ["pe", "read", "std"] }
 sbat = { version = "0.5.0", path = "../sbat", features = ["std"] }
-tabled = { version = "0.14.0", default-features = false, features = ["std"] }
+tabled = { version = "0.15.0", default-features = false, features = ["std"] }

--- a/sbat-tool/src/main.rs
+++ b/sbat-tool/src/main.rs
@@ -79,7 +79,7 @@ fn dump_section(input: &Path, section_name: &str) -> Result<()> {
 
 fn image_sbat_to_table_string(image_sbat: &ImageSbat) -> String {
     let mut builder = tabled::builder::Builder::default();
-    builder.set_header([
+    builder.push_record([
         "component",
         "gen",
         "vendor",
@@ -111,7 +111,7 @@ fn sbat_level_section_to_table_string(
     latest: &RevocationSbat,
 ) -> String {
     let mut builder = tabled::builder::Builder::default();
-    builder.set_header([
+    builder.push_record([
         "previous name",
         "previous gen",
         "latest name",


### PR DESCRIPTION
The `set_header` builder method has been removed, use `push_record` instead.