### PR TITLE
Enable automerge in renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,6 +7,7 @@
     "enabled": true
   },
   "rangeStrategy": "update-lockfile",
+  "automerge": true,
   "packageRules": [
     {
       "matchPackageNames": [


### PR DESCRIPTION
Despite the name, this doesn't actually allow PRs to merge automatically, because our repo settings require review for all PRs. This just avoids needing to manually click merge after approving a renovate PR.