### PR TITLE
Fix clippy lifetime lint

### DIFF
--- a/sbat/src/component.rs
+++ b/sbat/src/component.rs
@@ -25,8 +25,8 @@ pub struct Component<'a> {
 impl<'a> Component<'a> {
     /// Create a `Component`.
     #[must_use]
-    pub fn new(name: &AsciiStr, generation: Generation) -> Component {
-        Component { name, generation }
+    pub fn new(name: &'a AsciiStr, generation: Generation) -> Self {
+        Self { name, generation }
     }
 
     /// Parse a `Component` from a `Record`.


### PR DESCRIPTION
Also use `Self` to make this function more consistent with the rest of the code.
